### PR TITLE
pytest-lazy-fixture v0.6.3 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - pytest >=3.2.5
 
 test:
+  files:
+    - test.py
   imports:
     - pytest_lazyfixture
   requires:
@@ -32,7 +34,7 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest {{ RECIPE_DIR }}/test.py
+    - pytest -v test.py
 
 about:
   home: https://github.com/TvoroG/pytest-lazy-fixture

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-lazy-fixture" %}
 {% set version = "0.6.3" %}
-{% set hash = "0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac" %}
+
 package:
   name: {{ name }}
   version: {{ version }}
@@ -8,19 +8,18 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0]}}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash }}
+  sha256: 0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
+  host:
     - pip
     - python
     - setuptools
-
+    - wheel
   run:
     - python
     - pytest >=3.2.5
@@ -29,8 +28,10 @@ test:
   imports:
     - pytest_lazyfixture
   requires:
+    - pip
     - pytest
   commands:
+    - pip check
     - pytest {{ RECIPE_DIR }}/test.py
 
 about:
@@ -38,8 +39,11 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'It helps to use fixtures in pytest.mark.parametrize'
+  summary: It helps to use fixtures in pytest.mark.parametrize
+  description: |
+    Use your fixtures in @pytest.mark.parametrize.
   dev_url: https://github.com/TvoroG/pytest-lazy-fixture
+  doc_url: https://github.com/TvoroG/pytest-lazy-fixture/tree/v{{ version }}#usage
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-3432] pytest-lazy-fixture 0.6.3 ❄️ 

- upstream: https://github.com/TvoroG/pytest-lazy-fixture/tree/v0.6.3
- dependency files:
    - https://github.com/TvoroG/pytest-lazy-fixture/blob/v0.6.3/setup.py
- conda-forge: https://github.com/conda-forge/pytest-lazy-fixture-feedstock/blob/main/recipe/meta.yaml

**Destination channel:** Snowflake

**Changes**
- fix recipe
- add abs file


**Dependency for**
- AnacondaRecipes/omegaconf-feedstock#2



[PKG-3432]: https://anaconda.atlassian.net/browse/PKG-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ